### PR TITLE
fix: fixed template3 css & portfolio data input page modify

### DIFF
--- a/src/main/webapp/WEB-INF/views/portfolio_one.jsp
+++ b/src/main/webapp/WEB-INF/views/portfolio_one.jsp
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/portfolio_one.css?ver=1" media="screen">
     
     <title>addData</title>
-	<link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/addData.css?ver=12" media="screen">
+	<link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/addData.css?ver=14" media="screen">
     <script class="u-script" type="text/javascript" src="<%=request.getContextPath()%>/resources/js/linkCheck.js?ver=6"></script>
 
     
@@ -940,6 +940,7 @@
 	<jsp:include page="/WEB-INF/views/basic/header.jsp"/>
     <section class="u-clearfix u-grey-5 u-section-1" id="sec-428b">
       <div class="u-clearfix u-sheet u-sheet-1">
+      	<p class="p_text">**미리보기를 통해 포트폴리오의 완성도를 확인하세요**</p>
         <h5 class="u-custom-font u-text u-text-1">새 포트폴리오 만들기</h5><span class="u-custom-color-1 u-hidden-sm u-hidden-xs u-icon u-icon-circle u-spacing-9 u-text-white u-icon-1"><svg class="u-svg-link" preserveAspectRatio="xMidYMin slice" viewBox="0 0 42 42" style=""><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-7536"></use></svg><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" class="u-svg-content" viewBox="0 0 42 42" x="0px" y="0px" id="svg-7536" style="enable-background:new 0 0 42 42;"><path d="M37.059,16H26V4.941C26,2.224,23.718,0,21,0s-5,2.224-5,4.941V16H4.941C2.224,16,0,18.282,0,21s2.224,5,4.941,5H16v11.059
 	C16,39.776,18.282,42,21,42s5-2.224,5-4.941V26h11.059C39.776,26,42,23.718,42,21S39.776,16,37.059,16z"></path></svg></span>
 	

--- a/src/main/webapp/WEB-INF/views/portfolio_three.jsp
+++ b/src/main/webapp/WEB-INF/views/portfolio_three.jsp
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/portfolio_one.css" media="screen">
     
     <title>addData</title>
-	<link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/addData.css" media="screen">
+	<link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/addData.css?ver=1" media="screen">
     <meta name="generator" content="Nicepage 3.3.7, nicepage.com">
     
     <link id="u-theme-google-font" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i|Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i">
@@ -1108,6 +1108,7 @@
 <jsp:include page="/WEB-INF/views/basic/header.jsp"/>
     <section class="u-clearfix u-grey-5 u-section-1" id="sec-428b">
       <div class="u-clearfix u-sheet u-sheet-1">
+      	<p class="p_text">**미리보기를 통해 포트폴리오의 완성도를 확인하세요**</p>
         <h5 class="u-custom-font u-text u-text-1" style="color:#F76F6F;">포트폴리오 수정중..</h5><span class="u-custom-color-1 u-hidden-sm u-hidden-xs u-icon u-icon-circle u-spacing-9 u-text-white u-icon-1"><svg class="u-svg-link" preserveAspectRatio="xMidYMin slice" viewBox="0 0 42 42" style=""><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-7536"></use></svg><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" class="u-svg-content" viewBox="0 0 42 42" x="0px" y="0px" id="svg-7536" style="enable-background:new 0 0 42 42;"><path d="M37.059,16H26V4.941C26,2.224,23.718,0,21,0s-5,2.224-5,4.941V16H4.941C2.224,16,0,18.282,0,21s2.224,5,4.941,5H16v11.059
 	C16,39.776,18.282,42,21,42s5-2.224,5-4.941V26h11.059C39.776,26,42,23.718,42,21S39.776,16,37.059,16z"></path></svg></span>
 	

--- a/src/main/webapp/WEB-INF/views/templates/template3.jsp
+++ b/src/main/webapp/WEB-INF/views/templates/template3.jsp
@@ -17,7 +17,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script> -->
     
     <!-- template3 css -->
-    <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/template3.css?ver=28">
+    <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/template3.css?ver=29">
     <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/toolTip.css?ver=5">
     <script class="u-script" type="text/javascript" src="<%=request.getContextPath()%>/resources/js/txtLengthLimit.js?ver=3" defer=""></script>
     <title>portfolio</title>

--- a/src/main/webapp/resources/css/nicepage/addData.css
+++ b/src/main/webapp/resources/css/nicepage/addData.css
@@ -1,3 +1,11 @@
+.p_text{
+	position: relative;
+    float: right;
+    margin: 0;
+    margin-top: 1%;
+    color: gray;
+    font-size: 10px;
+}
 .u-section-1 {
   background-image: none;
 }
@@ -621,7 +629,7 @@
 
   .u-section-1 .u-text-1 {
     width: auto;
-    margin-top: 87px;
+    margin-top: 50px;
     margin-right: 619px;
     margin-left: 50px;
   }

--- a/src/main/webapp/resources/css/template3.css
+++ b/src/main/webapp/resources/css/template3.css
@@ -57,11 +57,13 @@
 
 
 .right{
-  position:absolute;
-  float:left;
-  margin-left:40%;
-  width:58%;
-  padding-left:2%;
+	  overflow:auto;
+	  position:relative;
+	  float:left;
+	  margin-left:43%;
+	  width:58%;
+	  height:100%;
+	  padding-left:2%;
 }
 
 .myInfo, .sgca{


### PR DESCRIPTION
template3.jsp에서 개발&활동 란에 내용이 overflow될 경우 scroll이 추가되도록 css 수정.
portfolio의 데이터 입력 페이지(portfolio_one.jsp/portfolio_three.jsp)에 미리보기 관련
문구를 추가함.