### PR TITLE
fix : fixed recruit_detail page

### DIFF
--- a/src/main/webapp/WEB-INF/views/recruitInfo_board.jsp
+++ b/src/main/webapp/WEB-INF/views/recruitInfo_board.jsp
@@ -5,8 +5,13 @@
   <head>
     
     <title>JobInfoHome</title>
-    <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/recruit_home.css?ver=<%=System.currentTimeMillis()%>" media="screen">
+    <!-- jQuery -->
+  	<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.10.2.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     
+    <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/recruit_home.css?ver=<%=System.currentTimeMillis()%>" media="screen">
+        
     <script class="u-script" type="text/javascript" src="<%=request.getContextPath()%>/resources/js/List.js?ver=1"></script>
   </head>
   <body class="u-body">

--- a/src/main/webapp/WEB-INF/views/recruit_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/recruit_detail.jsp
@@ -12,18 +12,23 @@
     <script src="https://code.jquery.com/jquery-1.10.2.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     
-     
-    <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/recruit_nicepage.css?ver=3" media="screen">
+    
+    <link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/recruit_nicepage.css?ver=<%=System.currentTimeMillis()%>" media="screen">
 	<link rel="stylesheet" href="<%=request.getContextPath()%>/resources/css/nicepage/recruit_detail.css?ver=<%=System.currentTimeMillis()%>" media="screen">
 
 	<script class="u-script" type="text/javascript" src="<%=request.getContextPath()%>/resources/js/recruit_detail.js?ver=<%=System.currentTimeMillis()%>" media="screen"></script>
 	<!-- 원 차트 -->
 	<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-	<!-- <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script> -->
-
+	
+	
+    <link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/innks/NanumSquareRound/master/nanumsquareround.min.css">
+    <link rel="stylesheet" type="text/css" href="<%=request.getContextPath()%>/resources/css/index.css">
+        
+    <script class="u-script" type="text/javascript" src="<%=request.getContextPath()%>/resources/js/nicepage/jquery.js" defer=""></script>
+    <script class="u-script" type="text/javascript" src="<%=request.getContextPath()%>/resources/js/nicepage/nicepage.js" defer=""></script>
   </head>
   <body class="u-body">
-<jsp:include page="/WEB-INF/views/basic/header.jsp"/>
+<%-- <jsp:include page="/WEB-INF/views/basic/header.jsp"/> --%>
   
   	<!-- detail page 헤더 (직업 이름이랑 설명란) -->
     <section class="u-align-center u-clearfix u-section-1" id="sec-920a">
@@ -613,7 +618,7 @@
       </div>
     </section>
     
-    <jsp:include page="/WEB-INF/views/basic/footer.jsp"/>
+    <%-- <jsp:include page="/WEB-INF/views/basic/footer.jsp"/> --%>
     
   </body>
   

--- a/src/main/webapp/resources/css/nicepage/recruit_detail.css
+++ b/src/main/webapp/resources/css/nicepage/recruit_detail.css
@@ -901,7 +901,7 @@
   .u-section-2 .u-group-5 {
     min-height: 313px;
     margin-top: 9px;
-    margin-right: auto;
+    /* margin-right: auto; */
   }
 
   .u-section-2 .u-text-6 {

--- a/src/main/webapp/resources/css/nicepage/recruit_nicepage.css
+++ b/src/main/webapp/resources/css/nicepage/recruit_nicepage.css
@@ -17848,10 +17848,17 @@ a.pswp__share--download:hover {
 }
 .u-tabs .u-tab-content > .u-tab-pane {
   flex: 1;
-  display: none;
-}
+  display: flex !important;
+  visibility: hidden !important;
+  position: absolute !important;
+  
+} 
 .u-tabs .u-tab-content > .u-tab-active {
-  display: flex;
+   flex: 1;
+   display: flex !important; 
+   visibility: visible !important;
+   position: absolute !important;
+   
 }
 .u-tabs.u-tab-links-align-left .u-tab-list {
   justify-content: flex-start;

--- a/src/main/webapp/resources/js/recruit_detail.js
+++ b/src/main/webapp/resources/js/recruit_detail.js
@@ -293,6 +293,8 @@ $( document ).ready(function() {
 				    
 			    	var len;
 			    	$(".four_jobSumProspect").empty();
+			    	$(".schDpt").empty();
+			    	$(".edubg").empty();
 			    	if(four.jobSumProspect!=null){
 				    	//차트그리기(일자리 전망)
 				    	google.charts.load('current', {packages: ['corechart']});
@@ -310,6 +312,7 @@ $( document ).ready(function() {
 				    		var chart = new google.visualization.PieChart(document.getElementById("jobSumProspect")); 
 				    		chart.draw(data3, options); 
 				    	}
+				    	
 					}
 			    	
 			   	},


### PR DESCRIPTION
직업에 대한 자세한 정보를 확인할 수 있는 페이지에 구글 차트 API 오류가 있었다.
세번째, 네번째 탭에서 한 탭은 'Cannot read property 'length' of undefined' 에러가 떴다.
이 에러는 Tab의 css 중 active한 탭 외의 탭에 display:none;을 적용했기 때문에 발생했던 문제였다.
때문에 non-active한 탭에서는 display:none 대신에 다른 css를 적용해주었더니 문제가 해결되었다.

하지만 세번째 탭의 css가 전체적으로 수정이 필요하다.